### PR TITLE
Usability fixes

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -352,7 +352,7 @@ impl Platform for LinuxPlatform {
     }
 
     fn read_credentials(&self, url: &str) -> Task<Result<Option<(String, Vec<u8>)>>> {
-        unimplemented!()
+        self.background_executor().spawn(async move { Ok(None) })
     }
 
     fn delete_credentials(&self, url: &str) -> Task<Result<()>> {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -129,6 +129,7 @@ impl Platform for LinuxPlatform {
                                 if let Some(ref mut fun) = self.callbacks.lock().quit {
                                     fun();
                                 }
+                                self.quit();
                             }
                         }
                     }


### PR DESCRIPTION
Blade port does not currently actually quit to the terminal when the window closes. 

Also when redirecting stdout to a file, triggers read_credentials, which causes a crash.
