### PR TITLE
Blade graphics fixes

### DIFF
--- a/crates/gpui/src/platform/linux/window.rs
+++ b/crates/gpui/src/platform/linux/window.rs
@@ -399,7 +399,11 @@ impl PlatformWindow for LinuxWindow {
     fn invalidate(&self) {}
 
     fn draw(&self, scene: &crate::Scene) {
+        let extent = query_render_extent(&self.0.xcb_connection, self.0.x_window);
         let mut inner = self.0.inner.lock();
+        if inner.renderer.viewport_size() != extent {
+            inner.renderer.resize(extent);
+        }
         inner.renderer.draw(scene);
     }
 


### PR DESCRIPTION
This adds a couple of checks for the actual window extent.

As per your Warning comment. It does appear that the gpu_extent gets invalidated after gpu::Context::init_windowed.

The second is when resizing quickly. Is this a perf issue being a blocking(?) call in the draw path? Not sure how else to do it though